### PR TITLE
Add read-only and read-write roles for the Elasticsearch database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.tfvars
 .mypy_cache
 __pycache__
 .python-version

--- a/dmarc_import.tf
+++ b/dmarc_import.tf
@@ -3,8 +3,7 @@
 #-------------------------------------------------------------------------------
 
 module "dmarc_import" {
-  # source = "github.com/cisagov/dmarc-import-tf-module"
-  source = "../dmarc-import-tf-module"
+  source = "github.com/cisagov/dmarc-import-tf-module"
 
   providers = {
     aws = aws.dnsprovisionaccount

--- a/elasticsearchreadonly_policy.tf
+++ b/elasticsearchreadonly_policy.tf
@@ -1,0 +1,24 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows read-only access to the
+# dmarc-import Elasticsearch database in the DNS account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "elasticsearchreadonly_doc" {
+  statement {
+    actions = [
+      "es:ESHttpGet",
+    ]
+    resources = [
+      module.dmarc_import.elasticsearch_domain.arn,
+      "${module.dmarc_import.elasticsearch_domain.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "elasticsearchreadonly_policy" {
+  provider = aws.dnsprovisionaccount
+
+  description = var.elasticsearchreadonly_role_description
+  name        = var.elasticsearchreadonly_role_name
+  policy      = data.aws_iam_policy_document.elasticsearchreadonly_doc.json
+}

--- a/elasticsearchreadonly_role.tf
+++ b/elasticsearchreadonly_role.tf
@@ -1,0 +1,38 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows read-only access to the dmarc-import
+# Elasticsearch database in the DNS account.
+# ------------------------------------------------------------------------------
+
+# An IAM policy document that allows the users account and the CyHy
+# account to assume the role.
+data "aws_iam_policy_document" "elasticsearchreadonly_assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        local.users_account_id,
+        var.cyhy_account_id,
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "elasticsearchreadonly_role" {
+  provider = aws.dnsprovisionaccount
+
+  assume_role_policy = data.aws_iam_policy_document.elasticsearchreadonly_assume_role_doc.json
+  description        = var.elasticsearchreadonly_role_description
+  name               = var.elasticsearchreadonly_role_name
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "elasticsearchreadonly_policy_attachment" {
+  provider = aws.dnsprovisionaccount
+
+  policy_arn = aws_iam_policy.elasticsearchreadonly_policy.arn
+  role       = aws_iam_role.elasticsearchreadonly_role.name
+}

--- a/elasticsearchreadwrite_policy.tf
+++ b/elasticsearchreadwrite_policy.tf
@@ -1,0 +1,24 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows read and write access to the
+# dmarc-import Elasticsearch database in the DNS account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "elasticsearchreadwrite_doc" {
+  statement {
+    actions = [
+      "es:ESHttp*",
+    ]
+    resources = [
+      module.dmarc_import.elasticsearch_domain.arn,
+      "${module.dmarc_import.elasticsearch_domain.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "elasticsearchreadwrite_policy" {
+  provider = aws.dnsprovisionaccount
+
+  description = var.elasticsearchreadwrite_role_description
+  name        = var.elasticsearchreadwrite_role_name
+  policy      = data.aws_iam_policy_document.elasticsearchreadwrite_doc.json
+}

--- a/elasticsearchreadwrite_role.tf
+++ b/elasticsearchreadwrite_role.tf
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows read and write access to the
+# dmarc-import Elasticsearch database in the DNS account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "elasticsearchreadwrite_role" {
+  provider = aws.dnsprovisionaccount
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = var.elasticsearchreadwrite_role_description
+  name               = var.elasticsearchreadwrite_role_name
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "elasticsearchreadwrite_policy_attachment" {
+  provider = aws.dnsprovisionaccount
+
+  policy_arn = aws_iam_policy.elasticsearchreadwrite_policy.arn
+  role       = aws_iam_role.elasticsearchreadwrite_role.name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,13 @@
+output "elasticsearchreadonly_role" {
+  value       = aws_iam_role.elasticsearchreadonly_role
+  description = "IAM role that allows sufficient permissions to read (but not write) to the dmarc-import Elasticsearch database."
+}
+
+output "elasticsearchreadwrite_role" {
+  value       = aws_iam_role.elasticsearchreadwrite_role
+  description = "IAM role that allows sufficient permissions to read and write to the dmarc-import Elasticsearch database."
+}
+
 output "provisiondmarcimport_policy" {
   value       = aws_iam_policy.provisiondmarcimport
   description = "IAM policy that allows sufficient permissions to provision the dmarc-import infrastructure."

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "cyhy_account_id" {
+  type        = string
+  description = "The ID of the CyHy account."
+}
+
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
@@ -26,6 +31,30 @@ variable "elasticsearch_index" {
   type        = string
   description = "The Elasticsearch index to which to write DMARC aggregate report data."
   default     = "dmarc_aggregate_reports"
+}
+
+variable "elasticsearchreadonly_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (and policy) that allows sufficient permissions to read (but not write) to the dmarc-import Elasticsearch database."
+  default     = "Allows sufficient permissions to read (but not write) to the dmarc-import Elasticsearch database."
+}
+
+variable "elasticsearchreadonly_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (and policy) that allows sufficient permissions to read (but not write) the to dmarc-import Elasticsearch database."
+  default     = "ElasticsearchReadOnly"
+}
+
+variable "elasticsearchreadwrite_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (and policy) that allows sufficient permissions to read and write to the dmarc-import Elasticsearch database."
+  default     = "Allows sufficient permissions to read and write to the dmarc-import Elasticsearch database."
+}
+
+variable "elasticsearchreadwrite_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (and policy) that allows sufficient permissions to read and write the to dmarc-import Elasticsearch database."
+  default     = "ElasticsearchReadWrite"
 }
 
 variable "elasticsearch_type" {


### PR DESCRIPTION
## 🗣 Description

This pull request adds read-only and read-write roles for the Elasticsearch database.

## 💭 Motivation and Context

The BOD Docker instance needs to be able to read the Elasticsearch database in order to generate the Trustworthy Email reports.

## 🧪 Testing

These changes have been applied to production and used to generate this week's Trustworthy Email reports.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
