### PR TITLE
Allow the ES read-only role to delete scroll contexts

### DIFF
--- a/elasticsearchreadonly_policy.tf
+++ b/elasticsearchreadonly_policy.tf
@@ -13,6 +13,20 @@ data "aws_iam_policy_document" "elasticsearchreadonly_doc" {
       "${module.dmarc_import.elasticsearch_domain.arn}/*",
     ]
   }
+
+  # This statement allows the deletion of scroll contexts.  These are
+  # expensive resources, so there is an upper limit on the number of
+  # them that can be open at once.  They should be deleted as soon as
+  # possible after use, and their deletion does not actually delete
+  # any data from the database.
+  statement {
+    actions = [
+      "es:ESHttpDelete",
+    ]
+    resources = [
+      "${module.dmarc_import.elasticsearch_domain.arn}/_search/scroll",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "elasticsearchreadonly_policy" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies a policy to allow the Elasticsearch read-only role to delete scroll contexts.

## 💭 Motivation and context ##

These are expensive resources, so there is an upper limit on the number of them that can be open at once.  They should be deleted as soon as possible after use, and their deletion does not actually delete any data from the database.

Scroll contexts are eventually garbage collected, but this weekend (January 1-2, 2022) we had a problem with the BOD 18-01 reporting where a few reports failed because too many scroll contexts were open at once.  This change allows us to delete scroll contexts as soon as we are finished with them and therefore remedy that problem.

See also cisagov/trustymail_reporter#60, which makes use of these changes.

## 🧪 Testing ##

I applied these changes to our production COOL environment and found that they functioned exactly as intended.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.